### PR TITLE
Fix missplenings in some properties of BitSlider

### DIFF
--- a/src/Client/Web/Bit.Client.Web.BlazorUI/Components/Sliders/BitSlider.razor
+++ b/src/Client/Web/Bit.Client.Web.BlazorUI/Components/Sliders/BitSlider.razor
@@ -42,7 +42,7 @@
                        min="@Min"
                        max="@Max"
                        step="@Step"
-                       @bind-value="@fisrtInputValue"
+                       @bind-value="@firstInputValue"
                        @oninput="@(args => HandleInput(args, true))"
                        disabled=@(!IsEnabled)
                        role="slider"
@@ -52,14 +52,14 @@
                        aria-label="@Label"
                        aria-valuemin="@Min"
                        aria-valuemax="@Max"
-                       aria-valuetext="@GetAriaValueText(fisrtInputValue.GetValueOrDefault())"
-                       aria-valuenow="@fisrtInputValue" />
+                       aria-valuetext="@GetAriaValueText(firstInputValue.GetValueOrDefault())"
+                       aria-valuenow="@firstInputValue" />
                 <input id="@($"max-{sliderBoxId}")"
                        type="range"
                        min="@Min"
                        max="@Max"
                        step="@Step"
-                       @bind-value="@secoundInputValue"
+                       @bind-value="@secondInputValue"
                        @oninput="@(args => HandleInput(args, false))"
                        disabled=@(!IsEnabled)
                        role="slider"
@@ -69,8 +69,8 @@
                        aria-label="@Label"
                        aria-valuemin="@Min"
                        aria-valuemax="@Max"
-                       aria-valuetext="@GetAriaValueText(secoundInputValue.GetValueOrDefault())"
-                       aria-valuenow="@secoundInputValue" />
+                       aria-valuetext="@GetAriaValueText(secondInputValue.GetValueOrDefault())"
+                       aria-valuenow="@secondInputValue" />
             </div>
             @if (ShowValue && IsVertical is false)
             {

--- a/src/Client/Web/Bit.Client.Web.BlazorUI/Components/Sliders/BitSlider.razor.cs
+++ b/src/Client/Web/Bit.Client.Web.BlazorUI/Components/Sliders/BitSlider.razor.cs
@@ -9,8 +9,8 @@ namespace Bit.Client.Web.BlazorUI
 {
     public partial class BitSlider
     {
-        private double? fisrtInputValue;
-        private double? secoundInputValue;
+        private double? firstInputValue;
+        private double? secondInputValue;
         private double? upperValue;
         private double? lowerValue;
         private double? value;
@@ -239,22 +239,22 @@ namespace Bit.Client.Web.BlazorUI
                 {
                     if (isFirstInput)
                     {
-                        fisrtInputValue = Convert.ToDouble(e.Value, CultureInfo.InvariantCulture);
+                        firstInputValue = Convert.ToDouble(e.Value, CultureInfo.InvariantCulture);
                     }
                     else
                     {
-                        secoundInputValue = Convert.ToDouble(e.Value, CultureInfo.InvariantCulture);
+                        secondInputValue = Convert.ToDouble(e.Value, CultureInfo.InvariantCulture);
                     }
 
-                    if (fisrtInputValue < secoundInputValue)
+                    if (firstInputValue < secondInputValue)
                     {
-                        lowerValue = fisrtInputValue;
-                        upperValue = secoundInputValue;
+                        lowerValue = firstInputValue;
+                        upperValue = secondInputValue;
                     }
                     else
                     {
-                        lowerValue = secoundInputValue;
-                        upperValue = fisrtInputValue;
+                        lowerValue = secondInputValue;
+                        upperValue = firstInputValue;
                     }
 
                     FillSlider();
@@ -272,7 +272,7 @@ namespace Bit.Client.Web.BlazorUI
         {
             if (IsRanged)
             {
-                styleProgress = $"--l: {fisrtInputValue}; --h: {secoundInputValue}; --min: {Min}; --max: {Max}";
+                styleProgress = $"--l: {firstInputValue}; --h: {secondInputValue}; --min: {Min}; --max: {Max}";
                 if (IsVertical)
                 {
                     styleContainer = $"width: {inputHeight}px; height: {inputHeight}px;";
@@ -301,13 +301,13 @@ namespace Bit.Client.Web.BlazorUI
 
             if (upper > lower)
             {
-                fisrtInputValue = lower;
-                secoundInputValue = upper;
+                firstInputValue = lower;
+                secondInputValue = upper;
             }
             else
             {
-                fisrtInputValue = upper;
-                secoundInputValue = lower;
+                firstInputValue = upper;
+                secondInputValue = lower;
             }
         }
 


### PR DESCRIPTION
This resolves #748 by fixing the misspellings of
`firstInputValue` and `secondInputValue` properties of
`BitSlider.razor.cs`