### PR TITLE
Correct 2-way bound `SelectedKey` in `BitPivot` (#1815)

### DIFF
--- a/src/Client/Web/Bit.Client.Web.BlazorUI/Components/Pivot/BitPivot.razor.cs
+++ b/src/Client/Web/Bit.Client.Web.BlazorUI/Components/Pivot/BitPivot.razor.cs
@@ -107,6 +107,8 @@ namespace Bit.Client.Web.BlazorUI
             SelectedItem = item;
             selectedKey = item.Key;
 
+            _ = SelectedKeyChanged.InvokeAsync(selectedKey);
+
             StateHasChanged();
 
             await OnLinkClick.InvokeAsync(item);


### PR DESCRIPTION
this closes #1815 