### PR TITLE
Set text-align left in error validation on the TodoTemplate project (#1973)

### DIFF
--- a/src/Tooling/Bit.Tooling.Templates/TodoTemplate/Web/Styles/shared/_form.scss
+++ b/src/Tooling/Bit.Tooling.Templates/TodoTemplate/Web/Styles/shared/_form.scss
@@ -84,6 +84,7 @@
     font-size: rem(12px);
     line-height: rem(16px);
     color: $Red;
+    text-align: left;
 }
 
 .form-checkbox {


### PR DESCRIPTION
This closes #1973 